### PR TITLE
Fix Broken Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ RUN [ "corepack", "enable" ]
 RUN [ "corepack", "prepare", "pnpm@latest", "--activate" ]
 
 RUN [ "pnpm", "install" ]
-RUN [ "pnpm", "build" ]
 
 ENV SUPABASE_URL ""
 ENV SUPABASE_KEY ""
 
-ENTRYPOINT [ "node" ]
-CMD [ "/app/.output/server/index.mjs" ]
+ENTRYPOINT [ "sh" ]
+CMD [ "/app/entrypoint.sh ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pnpm build
+node /app/.output/server/index.mjs


### PR DESCRIPTION
Delay pnpm build until runtime to ensure that the correct environment variables are set.